### PR TITLE
fix: update health check and CORS configuration

### DIFF
--- a/k8s/base/deployment.yaml
+++ b/k8s/base/deployment.yaml
@@ -33,13 +33,13 @@ spec:
               memory: "512Mi"
           readinessProbe:
             httpGet:
-              path: /health
+              path: /healthz
               port: 3000
             initialDelaySeconds: 5
             periodSeconds: 10
           livenessProbe:
             httpGet:
-              path: /health
+              path: /healthz
               port: 3000
             initialDelaySeconds: 15
             periodSeconds: 20

--- a/k8s/base/kustomization.yaml
+++ b/k8s/base/kustomization.yaml
@@ -14,6 +14,6 @@ commonLabels:
 images:
 - name: harbor.devostack.com/musclecode/musclecode-backend-execution-service
   newName: harbor.devostack.com/musclecode/musclecode-backend-execution-service
-  newTag: 07378ec7a72a9d03a78cd311e754db4dd051ba77
+  newTag: 7906d2e1cd5c6ffd7d5349776e799268e24ef20d
 commonAnnotations:
   image-sha: 67e9e107b614c05fce6fa3b44ed787c7ee70e14c

--- a/src/main.ts
+++ b/src/main.ts
@@ -4,6 +4,7 @@ import { AppModule } from './app.module';
 async function bootstrap() {
   const app = await NestFactory.create(AppModule);
 
+  // TODO: only for dev
   app.enableCors({
     origin: ['http://localhost:5173'],
   });


### PR DESCRIPTION
- Changed health check endpoint from `/health` to `/healthz` in Kubernetes deployment
- Added CORS configuration with localhost origin (marked as dev-only)