### PR TITLE
feat: add Istio VirtualService for backend execution service

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+  "cSpell.words": ["musclecode"]
+}

--- a/k8s/base/kustomization.yaml
+++ b/k8s/base/kustomization.yaml
@@ -5,7 +5,7 @@ namespace: musclecode
 resources:
 - deployment.yaml
 - service.yaml
-
+- virtual-service.yaml
 commonLabels:
   app.kubernetes.io/name: musclecode-backend-execution-service
   app.kubernetes.io/part-of: musclecode

--- a/k8s/base/kustomization.yaml
+++ b/k8s/base/kustomization.yaml
@@ -14,6 +14,6 @@ commonLabels:
 images:
 - name: harbor.devostack.com/musclecode/musclecode-backend-execution-service
   newName: harbor.devostack.com/musclecode/musclecode-backend-execution-service
-  newTag: 5d6d132ef247639b06fe058a1fa00b9dea68cf1b
+  newTag: b4488bd945bf913503d3306a61e3dffdaa8fdd72
 commonAnnotations:
   image-sha: 67e9e107b614c05fce6fa3b44ed787c7ee70e14c

--- a/k8s/base/virtual-service.yaml
+++ b/k8s/base/virtual-service.yaml
@@ -1,0 +1,23 @@
+apiVersion: networking.istio.io/v1alpha3
+kind: VirtualService
+metadata:
+  name: istio-musclecode-backend-execution-service-virtualservice
+  namespace: musclecode-dev
+spec:
+  hosts:
+  - "execution-service.api.musclecode.devostack.com"
+  gateways:
+  - istio-system/istio-https-gateway
+  http:
+  - match:
+    - uri:
+        prefix: /
+    route:
+    - destination:
+        port:
+          number: 80
+        host: musclecode-backend-execution-service
+    retries:
+      attempts: 3
+      perTryTimeout: 2s
+    timeout: 10s

--- a/k8s/overlays/dev/kustomization.yaml
+++ b/k8s/overlays/dev/kustomization.yaml
@@ -24,3 +24,14 @@ patches:
       - op: replace
         path: /metadata/namespace
         value: musclecode-dev
+
+  - target:
+      kind: VirtualService
+      name: istio-musclecode-backend-execution-service-virtualservice
+    patch: |-
+      - op: replace
+        path: /metadata/namespace
+        value: musclecode-dev
+      - op: replace
+        path: /spec/hosts/0
+        value: "execution-service.dev.api.musclecode.devostack.com"

--- a/k8s/overlays/prod/kustomization.yaml
+++ b/k8s/overlays/prod/kustomization.yaml
@@ -24,3 +24,14 @@ patches:
       - op: replace
         path: /metadata/namespace
         value: musclecode-prod
+
+  - target:
+      kind: VirtualService
+      name: istio-musclecode-backend-execution-service-virtualservice
+    patch: |-
+      - op: replace
+        path: /metadata/namespace
+        value: musclecode-prod
+      - op: replace
+        path: /spec/hosts/0
+        value: "execution-service.api.musclecode.devostack.com"


### PR DESCRIPTION
- Created VirtualService for routing external traffic to the execution service
- Added VirtualService to base Kustomization configuration
- Configured dev and prod overlays with specific host and namespace settings
- Added VSCode spell-check configuration for 'musclecode'