### PR TITLE
chore: enhance OpenTelemetry resource attributes for Kubernetes observability

### DIFF
--- a/k8s/base/kustomization.yaml
+++ b/k8s/base/kustomization.yaml
@@ -15,6 +15,6 @@ commonLabels:
 images:
 - name: harbor.devostack.com/musclecode/musclecode-backend-execution-service
   newName: harbor.devostack.com/musclecode/musclecode-backend-execution-service
-  newTag: 531f2de208b2a5355c559639d82b02b8dfa923bb
+  newTag: 45b4bf82fec2194647e38daa8a2e75ff36e1330a
 commonAnnotations:
   image-sha: 67e9e107b614c05fce6fa3b44ed787c7ee70e14c

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -52,6 +52,8 @@ const resource = new Resource({
   'k8s.pod.name': config.K8S_POD_NAME,
 });
 
+console.log('Logger resources', resource);
+
 // Construct the OTLP URL using protocol, host, port, and path
 const otlpUrl = config.LOG_ENDPOINT;
 
@@ -81,11 +83,11 @@ const otelLogger = loggerProvider.getLogger('winston-logger');
 // Create and configure the Winston logger with both Console and Signoz transports
 const logger = winston.createLogger({
   level: config.LOG_LEVEL,
-  format: combine(timestamp(), otelLogFormat),
-  // TODO: read from file and update on deployment
-  defaultMeta: {},
+  defaultMeta: { attributes: {} },
   transports: [
-    new winston.transports.Console(),
+    new winston.transports.Console({
+      format: combine(timestamp(), otelLogFormat),
+    }),
     new SignozTransport({
       otelLogger,
     }),

--- a/src/tracing.ts
+++ b/src/tracing.ts
@@ -2,7 +2,11 @@ import { NodeSDK } from '@opentelemetry/sdk-node';
 import { getNodeAutoInstrumentations } from '@opentelemetry/auto-instrumentations-node';
 import { OTLPTraceExporter } from '@opentelemetry/exporter-trace-otlp-http';
 import { Resource } from '@opentelemetry/resources';
-import { ATTR_SERVICE_NAME } from '@opentelemetry/semantic-conventions';
+import {
+  ATTR_SERVICE_NAME,
+  ATTR_SERVICE_VERSION,
+  SEMRESATTRS_DEPLOYMENT_ENVIRONMENT,
+} from '@opentelemetry/semantic-conventions';
 import { config } from './config/load-config';
 
 const traceExporter = new OTLPTraceExporter({
@@ -11,8 +15,15 @@ const traceExporter = new OTLPTraceExporter({
 
 export const otelSDK = new NodeSDK({
   resource: new Resource({
-    [ATTR_SERVICE_NAME]: 'execution-worker',
-    environment: process.env.NODE_ENV || 'development',
+    [ATTR_SERVICE_NAME]: config.APP_NAME || 'my-service',
+    [ATTR_SERVICE_VERSION]: config.APP_VERSION || '0.1.0',
+    [SEMRESATTRS_DEPLOYMENT_ENVIRONMENT]: config.NODE_ENV,
+    // Kubernetes specific attributes
+    'k8s.node.name': config.HOSTNAME,
+    'k8s.cluster.name': config.K8S_CLUSTER_NAME,
+    'k8s.deployment.name': config.K8S_DEPLOYMENT_NAME,
+    'k8s.namespace.name': config.K8S_NAMESPACE,
+    'k8s.pod.name': config.K8S_POD_NAME,
   }),
   traceExporter,
   instrumentations: [getNodeAutoInstrumentations()],


### PR DESCRIPTION
- Updated logger to log resource configuration
- Expanded tracing resource attributes with Kubernetes metadata
- Added service name, version, and environment to resource configuration
- Included Kubernetes-specific attributes like node, cluster, deployment, namespace, and pod names